### PR TITLE
Inject Node compatible with Node-RED v1.x and/or NodeJS 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: node_js
 matrix:
   include:
     - node_js: "lts/*"
+    - node_js: 12
     - node_js: 11
     - node_js: 9
     - node_js: 8
   allow_failures:
+    - node_js: 12
     - node_js: 11
     - node_js: 9
     - node_js: 8

--- a/src/opcua-iiot-inject.html
+++ b/src/opcua-iiot-inject.html
@@ -127,7 +127,7 @@
 </script>
 
 <script type="text/javascript">
-  let injectNode = RED.nodes.registry.getNodeType('OPCUA-IIoT-Inject')
+  //let injectNode = RED.nodes.registry.getNodeType('OPCUA-IIoT-Inject')
   injectNode.oneditprepare = function () {
     let node = this
     let fieldPayloadType = $('#node-input-payloadType')
@@ -532,7 +532,7 @@
 </script>
 
 <script type="text/javascript">
-  let injectNode = RED.nodes.registry.getNodeType('OPCUA-IIoT-Inject')
+  //let injectNode = RED.nodes.registry.getNodeType('OPCUA-IIoT-Inject')
   injectNode.oneditsave = function () {
     let node = this
     let repeat = ''
@@ -648,7 +648,7 @@
 </script>
 
 <script type="text/javascript">
-  let injectNode = RED.nodes.registry.getNodeType('OPCUA-IIoT-Inject')
+  //let injectNode = RED.nodes.registry.getNodeType('OPCUA-IIoT-Inject')
   injectNode.label = function () {
     let suffix = ''
 


### PR DESCRIPTION
this solves issues #106 and #105 (Inject Node without configuration options on nodered v1.0.x and nodejs 12.x)